### PR TITLE
Fix issue for subscriptions where prevCondition is a subscriber

### DIFF
--- a/built/cluster/ClusterSubscriber.js
+++ b/built/cluster/ClusterSubscriber.js
@@ -63,6 +63,7 @@ class ClusterSubscriber {
         debug("stopped");
     }
     selectSubscriber() {
+        var _a, _b;
         const lastActiveSubscriber = this.lastActiveSubscriber;
         // Disconnect the previous subscriber even if there
         // will not be a new one.
@@ -116,13 +117,12 @@ class ClusterSubscriber {
         // Re-subscribe previous channels
         const previousChannels = { subscribe: [], psubscribe: [], ssubscribe: [] };
         if (lastActiveSubscriber) {
-            const condition = lastActiveSubscriber.condition || lastActiveSubscriber.prevCondition;
-            if (condition && condition.subscriber) {
-                previousChannels.subscribe = condition.subscriber.channels("subscribe");
-                previousChannels.psubscribe =
-                    condition.subscriber.channels("psubscribe");
-                previousChannels.ssubscribe =
-                    condition.subscriber.channels("ssubscribe");
+            const subscriber = ((_a = lastActiveSubscriber.condition) === null || _a === void 0 ? void 0 : _a.subscriber) ||
+                ((_b = lastActiveSubscriber.prevCondition) === null || _b === void 0 ? void 0 : _b.subscriber);
+            if (subscriber) {
+                previousChannels.subscribe = subscriber.channels("subscribe");
+                previousChannels.psubscribe = subscriber.channels("psubscribe");
+                previousChannels.ssubscribe = subscriber.channels("ssubscribe");
             }
         }
         if (previousChannels.subscribe.length ||

--- a/built/cluster/ClusterSubscriber.js
+++ b/built/cluster/ClusterSubscriber.js
@@ -33,6 +33,7 @@ class ClusterSubscriber {
             if (!this.started || !this.subscriber) {
                 return;
             }
+            // @ts-expect-error
             if ((0, util_1.getNodeKey)(this.subscriber.options) === key) {
                 debug("subscriber has left, selecting a new one...");
                 this.selectSubscriber();

--- a/lib/cluster/ClusterSubscriber.ts
+++ b/lib/cluster/ClusterSubscriber.ts
@@ -3,13 +3,14 @@ import ConnectionPool from "./ConnectionPool";
 import { getConnectionName, getNodeKey } from "./util";
 import { sample, noop, Debug } from "../utils";
 import Redis from "../Redis";
+import { Condition } from "../DataHandler";
 
 const debug = Debug("cluster:subscriber");
 
 export default class ClusterSubscriber {
   private started = false;
-  private subscriber: any = null;
-  private lastActiveSubscriber: any;
+  private subscriber: Redis | null = null;
+  private lastActiveSubscriber: Redis & { prevCondition?: Condition };
 
   constructor(
     private connectionPool: ConnectionPool,
@@ -27,6 +28,7 @@ export default class ClusterSubscriber {
       if (!this.started || !this.subscriber) {
         return;
       }
+      // @ts-expect-error
       if (getNodeKey(this.subscriber.options) === key) {
         debug("subscriber has left, selecting a new one...");
         this.selectSubscriber();

--- a/lib/cluster/ClusterSubscriber.ts
+++ b/lib/cluster/ClusterSubscriber.ts
@@ -140,14 +140,14 @@ export default class ClusterSubscriber {
     // Re-subscribe previous channels
     const previousChannels = { subscribe: [], psubscribe: [], ssubscribe: [] };
     if (lastActiveSubscriber) {
-      const condition =
-        lastActiveSubscriber.condition || lastActiveSubscriber.prevCondition;
-      if (condition && condition.subscriber) {
-        previousChannels.subscribe = condition.subscriber.channels("subscribe");
-        previousChannels.psubscribe =
-          condition.subscriber.channels("psubscribe");
-        previousChannels.ssubscribe =
-          condition.subscriber.channels("ssubscribe");
+      const subscriber =
+        lastActiveSubscriber.condition?.subscriber ||
+        lastActiveSubscriber.prevCondition?.subscriber;
+
+      if (subscriber) {
+        previousChannels.subscribe = subscriber.channels("subscribe");
+        previousChannels.psubscribe = subscriber.channels("psubscribe");
+        previousChannels.ssubscribe = subscriber.channels("ssubscribe");
       }
     }
     if (


### PR DESCRIPTION
## Change

Based on this ioredis PR: https://github.com/redis/ioredis/pull/1900

## Problem / Why

currently, cluster's "subscriber" check is done on "condition/preCondition" object level. But "condition.subscriber" property may be a boolean, not an object. So if "subscriber" as an object exists only on "prevCondition", we will never get there. This fix makes sure we pick the first available subscriber object (if any). This might be useful for us as "bull" uses subscriptions when dealing with queues.  

## References

- [Jira #:ID:](https://jira2.workday.com/browse/:ID:)
- Link to some slack message
- Link to other related resource
